### PR TITLE
Adiabiatic bar os32 test do not merge to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OpenStudio Model Articulation Gems
 
+## Version 0.4.0
+
+* Support Ruby ~> 2.7
+* Support for OpenStudio 3.2 (upgrade to extension gem 0.4.1 and standards gem 0.2.13.rc3)
+
 ## Version 0.3.1
 
 * Bump openstudio-extension-gem version to 0.3.2 to support updated workflow-gem

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,3 +8,4 @@ if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set
   openstudio_extension_gems()
     
 }
+

--- a/lib/measures/create_bar_from_building_type_ratios/measure.xml
+++ b/lib/measures/create_bar_from_building_type_ratios/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>create_bar_from_building_type_ratios</name>
   <uid>6e3a14f8-c3c7-4e03-bc51-bef8a52e1a05</uid>
-  <version_id>c569be27-f463-4721-8bfb-72bd6775d70e</version_id>
-  <version_modified>20200512T025555Z</version_modified>
+  <version_id>632174d7-2af9-4374-9f9d-89bd08967593</version_id>
+  <version_modified>20210416T201509Z</version_modified>
   <xml_checksum>2AF3A68E</xml_checksum>
   <class_name>CreateBarFromBuildingTypeRatios</class_name>
   <display_name>Create Bar From Building Type Ratios</display_name>
@@ -86,6 +86,26 @@
         <choice>
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
+        </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
         </choice>
         <choice>
           <value>Asm</value>
@@ -281,6 +301,26 @@
         <choice>
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
+        </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
         </choice>
         <choice>
           <value>Asm</value>
@@ -486,6 +526,26 @@
           <display_name>SuperMarket</display_name>
         </choice>
         <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
+        </choice>
+        <choice>
           <value>Asm</value>
           <display_name>Asm</display_name>
         </choice>
@@ -687,6 +747,26 @@
         <choice>
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
+        </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
         </choice>
         <choice>
           <value>Asm</value>
@@ -920,6 +1000,30 @@
         <choice>
           <value>90.1-2013</value>
           <display_name>90.1-2013</display_name>
+        </choice>
+        <choice>
+          <value>ComStock DOE Ref Pre-1980</value>
+          <display_name>ComStock DOE Ref Pre-1980</display_name>
+        </choice>
+        <choice>
+          <value>ComStock DOE Ref 1980-2004</value>
+          <display_name>ComStock DOE Ref 1980-2004</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2004</value>
+          <display_name>ComStock 90.1-2004</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2007</value>
+          <display_name>ComStock 90.1-2007</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2010</value>
+          <display_name>ComStock 90.1-2010</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2013</value>
+          <display_name>ComStock 90.1-2013</display_name>
         </choice>
         <choice>
           <value>NREL ZNE Ready 2017</value>
@@ -1591,13 +1695,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>EF514CF1</checksum>
+      <checksum>8B9DB10F</checksum>
     </file>
     <file>
       <filename>create_bar_from_building_type_ratios_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>058A6AF0</checksum>
+      <checksum>86193630</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/create_bar_from_building_type_ratios/tests/create_bar_from_building_type_ratios_test.rb
+++ b/lib/measures/create_bar_from_building_type_ratios/tests/create_bar_from_building_type_ratios_test.rb
@@ -166,7 +166,7 @@ class CreateBarFromBuildingTypeRatios_Test < Minitest::Test
     args['building_rotation'] = -90
     args['party_wall_stories_east'] = 2
     args['double_loaded_corridor'] = 'Primary Space Type'
-    args['make_mid_story_surfaces_adiabatic'] = false
+    args['make_mid_story_surfaces_adiabatic'] = true
     args['bar_division_method'] = 'Multiple Space Types - Individual Stories Sliced'
     # intersection errors only on this test
     # add diagnostic_intersect flag to use more detailed but slower intersection

--- a/lib/measures/create_bar_from_doe_building_type_ratios/measure.xml
+++ b/lib/measures/create_bar_from_doe_building_type_ratios/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>create_bar_from_doe_building_type_ratios</name>
   <uid>0de3cff9-c805-42c4-964e-18cb43a22c63</uid>
-  <version_id>1e92f356-df92-40c7-838e-30843c91521c</version_id>
-  <version_modified>20200509T155941Z</version_modified>
+  <version_id>0c9bb55b-173d-48dd-ba6f-1ca2b7c3c909</version_id>
+  <version_modified>20210416T201648Z</version_modified>
   <xml_checksum>5F523097</xml_checksum>
   <class_name>CreateBarFromDOEBuildingTypeRatios</class_name>
   <display_name>Create Bar From DOE Building Type Ratios</display_name>
@@ -87,6 +87,26 @@
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
         </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
+        </choice>
       </choices>
     </argument>
     <argument>
@@ -164,6 +184,26 @@
         <choice>
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
+        </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
         </choice>
       </choices>
     </argument>
@@ -251,6 +291,26 @@
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
         </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
+        </choice>
       </choices>
     </argument>
     <argument>
@@ -336,6 +396,26 @@
         <choice>
           <value>SuperMarket</value>
           <display_name>SuperMarket</display_name>
+        </choice>
+        <choice>
+          <value>Laboratory</value>
+          <display_name>Laboratory</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterLowITE</value>
+          <display_name>LargeDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>LargeDataCenterHighITE</value>
+          <display_name>LargeDataCenterHighITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterLowITE</value>
+          <display_name>SmallDataCenterLowITE</display_name>
+        </choice>
+        <choice>
+          <value>SmallDataCenterHighITE</value>
+          <display_name>SmallDataCenterHighITE</display_name>
         </choice>
       </choices>
     </argument>
@@ -452,6 +532,30 @@
         <choice>
           <value>90.1-2013</value>
           <display_name>90.1-2013</display_name>
+        </choice>
+        <choice>
+          <value>ComStock DOE Ref Pre-1980</value>
+          <display_name>ComStock DOE Ref Pre-1980</display_name>
+        </choice>
+        <choice>
+          <value>ComStock DOE Ref 1980-2004</value>
+          <display_name>ComStock DOE Ref 1980-2004</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2004</value>
+          <display_name>ComStock 90.1-2004</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2007</value>
+          <display_name>ComStock 90.1-2007</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2010</value>
+          <display_name>ComStock 90.1-2010</display_name>
+        </choice>
+        <choice>
+          <value>ComStock 90.1-2013</value>
+          <display_name>ComStock 90.1-2013</display_name>
         </choice>
         <choice>
           <value>NREL ZNE Ready 2017</value>
@@ -913,7 +1017,7 @@
       <filename>create_bar_from_doe_building_type_ratios_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>1C04409F</checksum>
+      <checksum>736B4EA7</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/create_bar_from_doe_building_type_ratios/tests/create_bar_from_doe_building_type_ratios_test.rb
+++ b/lib/measures/create_bar_from_doe_building_type_ratios/tests/create_bar_from_doe_building_type_ratios_test.rb
@@ -165,6 +165,7 @@ class CreateBarFromDOEBuildingTypeRatios_Test < Minitest::Test
     args['bldg_type_a'] = 'PrimarySchool'
     args['building_rotation'] = -90
     args['party_wall_stories_east'] = 2
+    args['make_mid_story_surfaces_adiabatic'] = true
 
     apply_measure_to_model(__method__.to_s.gsub('test_', ''), args, nil, nil, 1)
   end
@@ -328,6 +329,7 @@ class CreateBarFromDOEBuildingTypeRatios_Test < Minitest::Test
     args['ns_to_ew_ratio'] = 1.5
     args['num_stories_above_grade'] = 2
     # args["bar_division_method"] = 'Multiple Space Types - Simple Sliced'
+    args['make_mid_story_surfaces_adiabatic'] = true
 
     apply_measure_to_model(__method__.to_s.gsub('test_', ''), args, nil, nil, 8)
   end
@@ -378,6 +380,7 @@ class CreateBarFromDOEBuildingTypeRatios_Test < Minitest::Test
     args['ns_to_ew_ratio'] = 3.0
     args['perim_mult'] = 1.0
     args['custom_height_bar'] = false
+    args['make_mid_story_surfaces_adiabatic'] = true
 
     apply_measure_to_model(__method__.to_s.gsub('test_', ''), args, nil, nil, nil)
   end
@@ -393,6 +396,7 @@ class CreateBarFromDOEBuildingTypeRatios_Test < Minitest::Test
     args['ns_to_ew_ratio'] = 3.0
     args['perim_mult'] = 1.01
     args['custom_height_bar'] = false
+    args['make_mid_story_surfaces_adiabatic'] = true
 
     apply_measure_to_model(__method__.to_s.gsub('test_', ''), args, nil, nil, nil)
   end
@@ -421,6 +425,7 @@ class CreateBarFromDOEBuildingTypeRatios_Test < Minitest::Test
     args['ns_to_ew_ratio'] = 1.0
     args['perim_mult'] = 1.1
     args['custom_height_bar'] = false
+    args['make_mid_story_surfaces_adiabatic'] = true
 
     apply_measure_to_model(__method__.to_s.gsub('test_', ''), args, nil, nil, nil)
   end

--- a/openstudio-model-articulation.gemspec
+++ b/openstudio-model-articulation.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.7.0'
 
   spec.add_dependency 'bundler', '~> 2.1'
-  spec.add_dependency 'openstudio-extension', '~> 0.4.0'
-  spec.add_dependency 'openstudio-standards', '~> 0.2.12'
+  spec.add_dependency 'openstudio-extension', '~> 0.4.1'
+  spec.add_dependency 'openstudio-standards', '~> 0.2.13.rc3'
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
this doesn't need to be merged to develop it was just t confirm the issue was the floor/ceiling intersection and matching. The 6 failing tests now all set adiabatic to true, which is what the version of the measure used for ComStock already does by default.