### PR TITLE
remove minimum_operation argument

### DIFF
--- a/lib/measures/radiant_slab_with_doas/README.md
+++ b/lib/measures/radiant_slab_with_doas/README.md
@@ -95,14 +95,6 @@ Only applicable in radiant floor systems. This will greatly reduce system effect
 **Required:** true,
 **Model Dependent:** false
 
-### Minimum Operating Hours
-Fractional Hours Allowed, e.g. 30 min = 0.5
-**Name:** minimum_operation,
-**Type:** Double,
-**Units:** ,
-**Required:** true,
-**Model Dependent:** false
-
 ### Switch Over Time
 Minimum time limitation for when the system can switch between heating and cooling.  Fractional hours allowed, e.g. 30 min = 0.5.
 **Name:** switch_over_time,

--- a/lib/measures/radiant_slab_with_doas/measure.rb
+++ b/lib/measures/radiant_slab_with_doas/measure.rb
@@ -103,13 +103,6 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
     proportional_gain.setDefaultValue(0.3)
     args << proportional_gain
 
-    # make an argument for minimum operating hours
-    minimum_operation = OpenStudio::Measure::OSArgument.makeDoubleArgument('minimum_operation', true)
-    minimum_operation.setDisplayName('Minimum Operating Hours')
-    minimum_operation.setDescription('Fractional Hours Allowed, e.g. 30 min = 0.5')
-    minimum_operation.setDefaultValue(1.0)
-    args << minimum_operation
-
     # make an argument for switch over time
     switch_over_time = OpenStudio::Measure::OSArgument.makeDoubleArgument('switch_over_time', true)
     switch_over_time.setDisplayName('Switch Over Time')
@@ -176,7 +169,6 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
     include_carpet = runner.getBoolArgumentValue('include_carpet', user_arguments)
     control_strategy = runner.getStringArgumentValue('control_strategy', user_arguments)
     proportional_gain = runner.getDoubleArgumentValue('proportional_gain', user_arguments)
-    minimum_operation = runner.getDoubleArgumentValue('minimum_operation', user_arguments)
     switch_over_time = runner.getDoubleArgumentValue('switch_over_time', user_arguments)
     radiant_lockout = runner.getBoolArgumentValue('radiant_lockout', user_arguments)
     lockout_start_time = runner.getDoubleArgumentValue('lockout_start_time', user_arguments)
@@ -289,7 +281,6 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
                                                    include_carpet: include_carpet,
                                                    control_strategy: control_strategy,
                                                    proportional_gain: proportional_gain,
-                                                   minimum_operation: minimum_operation,
                                                    switch_over_time: switch_over_time,
                                                    radiant_lockout: radiant_lockout,
                                                    radiant_lockout_start_time: lockout_start_time,

--- a/lib/measures/radiant_slab_with_doas/measure.xml
+++ b/lib/measures/radiant_slab_with_doas/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>radiant_slab_with_doas</name>
   <uid>8091a0c3-7760-4da6-adf4-133d55872816</uid>
-  <version_id>d7f5c831-95c6-49e7-ad76-7f2052b7f620</version_id>
-  <version_modified>20230602T160042Z</version_modified>
+  <version_id>0aa5894b-04df-4143-9346-85d813fdac98</version_id>
+  <version_modified>2023-10-30T17:38:24Z</version_modified>
   <xml_checksum>C49A7DAB</xml_checksum>
   <class_name>RadiantSlabWithDoas</class_name>
   <display_name>Radiant Slab with DOAS</display_name>
@@ -159,15 +159,6 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
       <default_value>0.3</default_value>
     </argument>
     <argument>
-      <name>minimum_operation</name>
-      <display_name>Minimum Operating Hours</display_name>
-      <description>Fractional Hours Allowed, e.g. 30 min = 0.5</description>
-      <type>Double</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-      <default_value>1</default_value>
-    </argument>
-    <argument>
       <name>switch_over_time</name>
       <display_name>Switch Over Time</display_name>
       <description>Minimum time limitation for when the system can switch between heating and cooling.  Fractional hours allowed, e.g. 30 min = 0.5.</description>
@@ -284,10 +275,33 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
   </attributes>
   <files>
     <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>BFFB1AA6</checksum>
+    </file>
+    <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>9B9C0291</checksum>
+    </file>
+    <file>
       <filename>README.md.erb</filename>
       <filetype>erb</filetype>
       <usage_type>readmeerb</usage_type>
       <checksum>703C9964</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.9.0</identifier>
+        <min_compatible>2.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>10219EED</checksum>
     </file>
     <file>
       <filename>USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw</filename>
@@ -308,39 +322,16 @@ To reduce unmet hours, use an expanded comfort range as mentioned above, remove 
       <checksum>7CBAD8AA</checksum>
     </file>
     <file>
+      <filename>radiant_slab_with_doas_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>36014A9D</checksum>
+    </file>
+    <file>
       <filename>single_zone_office_5A.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
       <checksum>44FD3DF2</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>8618B20F</checksum>
-    </file>
-    <file>
-      <filename>LICENSE.md</filename>
-      <filetype>md</filetype>
-      <usage_type>license</usage_type>
-      <checksum>BFFB1AA6</checksum>
-    </file>
-    <file>
-      <filename>radiant_slab_with_doas_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>363DB98B</checksum>
-    </file>
-    <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.9.0</identifier>
-        <min_compatible>2.9.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>BE3F5928</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/radiant_slab_with_doas/tests/radiant_slab_with_doas_test.rb
+++ b/lib/measures/radiant_slab_with_doas/tests/radiant_slab_with_doas_test.rb
@@ -137,7 +137,7 @@ class RadiantSlabWithDoasTest < Minitest::Test
 
     # get arguments and test that they are what we are expecting
     arguments = measure.arguments(model)
-    assert_equal(15, arguments.size)
+    assert_equal(14, arguments.size)
     assert_equal('remove_existing_hvac', arguments[0].name)
     assert_equal('heating_plant_type', arguments[1].name)
     assert_equal('cooling_plant_type', arguments[2].name)
@@ -146,13 +146,12 @@ class RadiantSlabWithDoasTest < Minitest::Test
     assert_equal('include_carpet', arguments[5].name)
     assert_equal('control_strategy', arguments[6].name)
     assert_equal('proportional_gain', arguments[7].name)
-    assert_equal('minimum_operation', arguments[8].name)
-    assert_equal('switch_over_time', arguments[9].name)
-    assert_equal('radiant_lockout', arguments[10].name)
-    assert_equal('lockout_start_time', arguments[11].name)
-    assert_equal('lockout_end_time', arguments[12].name)
-    assert_equal('add_output_variables', arguments[13].name)
-    assert_equal('standards_template', arguments[14].name)
+    assert_equal('switch_over_time', arguments[8].name)
+    assert_equal('radiant_lockout', arguments[9].name)
+    assert_equal('lockout_start_time', arguments[10].name)
+    assert_equal('lockout_end_time', arguments[11].name)
+    assert_equal('add_output_variables', arguments[12].name)
+    assert_equal('standards_template', arguments[13].name)
   end
 
   def test_single_zone_office_5A_floor


### PR DESCRIPTION
removes the minimum_operation argument from the radiant method call in openstudio-standards. Wanted to pull this in before adjust UH in tests