### PR TITLE
Set climate zone in baseline measure test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenStudio Model Articulation Gems
 
+## Version 0.12.0
+* Support for OpenStudio 3.10 (upgrade to standards gem 0.8.2, extension gem 0.9.1)
+* todo add log after finalize bug fixes for this release
+
 ## Version 0.11.1
 * Update 'story_multiplier' argument to 'story_multiplier_method' for create_bar_from_building_type_ratios measure
 * Update dependencies for 3.9

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
  
-@Library('cbci_shared_libs@developExtension') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-OpenStudio(R), Copyright (c) 2008, 2024 Alliance for Sustainable Energy, LLC.
+OpenStudio(R), Copyright (c) 2008, 2025 Alliance for Sustainable Energy, LLC.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ bundle exec rake openstudio:test_with_openstudio
 
 |OpenStudio Model Articulation Gem|OpenStudio|Ruby|
 |:--------------:|:----------:|:--------:|
+| 0.12.0         | 3.10      | 3.2.2  |
+| 0.11.1         | 3.9      | 3.2.2  |
 | 0.11.0         | 3.9      | 3.2.2  |
 | 0.10.0         | 3.8      | 3.2.2  |
 | 0.9.0          | 3.7      | 2.7    |

--- a/lib/measures/create_baseline_building/measure.xml
+++ b/lib/measures/create_baseline_building/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>create_baseline_building</name>
   <uid>4de56e21-b6cd-45d9-8466-862507d228b2</uid>
-  <version_id>fff85669-8136-4b9c-9c2d-459678c195af</version_id>
-  <version_modified>2024-11-16T23:56:33Z</version_modified>
+  <version_id>3ed14c5e-a445-4818-b1c2-216c310c2716</version_id>
+  <version_modified>2025-06-12T23:44:21Z</version_modified>
   <xml_checksum>A514F332</xml_checksum>
   <class_name>CreateBaselineBuilding</class_name>
   <display_name>Create Baseline Building</display_name>
@@ -280,7 +280,7 @@
       <filename>create_baseline_building_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>8731D1E6</checksum>
+      <checksum>F0256467</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/create_baseline_building/tests/create_baseline_building_test.rb
+++ b/lib/measures/create_baseline_building/tests/create_baseline_building_test.rb
@@ -41,6 +41,7 @@ class CreateBaselineBuildingTest < Minitest::Unit::TestCase
     # set the weather file for the test model
     epw_file = OpenStudio::EpwFile.new("#{__dir__}/USA_TX_Houston-Bush.Intercontinental.AP.722430_TMY3.epw")
     OpenStudio::Model::WeatherFile.setWeatherFile(model, epw_file).get
+    OpenstudioStandards::Weather.model_set_climate_zone(model, 'ASHRAE 169-2013-2A')
 
     # Create an empty argument map
     arguments = measure.arguments(model)

--- a/lib/openstudio/model_articulation/version.rb
+++ b/lib/openstudio/model_articulation/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module ModelArticulation
-    VERSION = '0.11.1'
+    VERSION = '0.12.0'
   end
 end

--- a/openstudio-model-articulation.gemspec
+++ b/openstudio-model-articulation.gemspec
@@ -29,13 +29,17 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 3.2.2'
 
   spec.add_dependency 'bundler', '~> 2.4.10'
-  spec.add_dependency 'openstudio-extension', '~> 0.8.3'
-  spec.add_dependency 'openstudio-standards', '0.7.1'
+  spec.add_dependency 'openstudio-extension', '~> 0.9.1'
+  spec.add_dependency 'openstudio-standards', '0.8.2'
 
   # if we need the following dependencies pinned,
   # let's set them in extension-gem for next release
   spec.add_dependency 'multipart-post', '2.4.0'
 
+  spec.add_development_dependency 'rubocop', '1.50'
+  spec.add_development_dependency 'rubocop-checkstyle_formatter', '0.6.0'
+  spec.add_development_dependency 'rubocop-performance', '1.20.0'
+  spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'octokit', '4.18.0' # for change logs


### PR DESCRIPTION
Set the climate zone in the model in the CreateBaselineBuilding measure tests. This fixes an error where the tests fail because the baseline prm code cannot determine the climate zone required for space conditioning limits.