### PR TITLE
Fixes Issue #170

### DIFF
--- a/lib/measures/merge_floorspace_js_with_model/measure.rb
+++ b/lib/measures/merge_floorspace_js_with_model/measure.rb
@@ -227,7 +227,7 @@ class MergeFloorspaceJsWithModel < OpenStudio::Measure::ModelMeasure
       space_type.spaces.each do |space|
         unless space.thermalZone.is_initialized
           thermal_zone = OpenStudio::Model::ThermalZone.new(model)
-          thermal_zone.setName(space.name.to_s)
+          thermal_zone.setName("zone #{space.name.to_s}")
           space.setThermalZone(thermal_zone)
         end
       end

--- a/lib/measures/merge_floorspace_js_with_model/measure.xml
+++ b/lib/measures/merge_floorspace_js_with_model/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>merge_floorspace_js_with_model</name>
   <uid>16ef6369-6420-4f17-894c-a767895bcaa4</uid>
-  <version_id>08fb938b-1331-47e4-bcaa-07fae4abc783</version_id>
-  <version_modified>2025-08-01T14:58:34Z</version_modified>
+  <version_id>c3c232cf-cb02-4ce8-ad73-3caace5dfb60</version_id>
+  <version_modified>2026-06-17T22:04:59Z</version_modified>
   <xml_checksum>0AD1E2E2</xml_checksum>
   <class_name>MergeFloorspaceJsWithModel</class_name>
   <display_name>Merge FloorspaceJs with Model</display_name>
@@ -80,7 +80,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>23601781</checksum>
+      <checksum>410E985D</checksum>
     </file>
     <file>
       <filename>SDDC Office template.osm</filename>

--- a/lib/measures/merge_floorspace_js_with_model/tests/merge_floorspace_js_with_model_test.rb
+++ b/lib/measures/merge_floorspace_js_with_model/tests/merge_floorspace_js_with_model_test.rb
@@ -35,6 +35,9 @@ class MergeFloorspaceJsWithModelTest < Minitest::Test
     # store the number of spaces in the seed model
     num_spaces_seed = model.getSpaces.size
 
+    # capture existing zone names before running the measure
+    existing_zone_names = model.getThermalZones.map { |z| z.name.to_s }
+
     # get arguments
     arguments = measure.arguments(model)
     argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
@@ -68,6 +71,20 @@ class MergeFloorspaceJsWithModelTest < Minitest::Test
 
     # check that there is now 1 space
     # assert_equal(1, model.getSpaces.size - num_spaces_seed)
+
+    # verify that newly created thermal zones are prefixed with "zone "
+    # and that zone names do not exactly match the corresponding space name (Issue #170)
+    model.getSpaces.each do |space|
+      next unless space.thermalZone.is_initialized
+      zone_name = space.thermalZone.get.name.to_s
+      next if existing_zone_names.include?(zone_name)
+
+      space_name = space.name.to_s
+      assert(zone_name.start_with?('zone '),
+             "Expected newly created zone '#{zone_name}' to start with 'zone ' for space '#{space_name}'")
+      refute_equal(space_name, zone_name,
+                   "Thermal zone name '#{zone_name}' must not equal space name '#{space_name}'")
+    end
 
     # save the model to test output directory
     output_file_path = "#{File.dirname(__FILE__)}//output/test_output.osm"


### PR DESCRIPTION
I confirmed fix on the test model. I also confirmed that if I try to use space name as zone name in OS app that it renames it, so adding prefix seems like good approach. I hard coded "zone " but could make an argument if there is interest or an option to look for and swap out "space" if it is found with "zone"